### PR TITLE
Spelling correction in src/index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -163,7 +163,7 @@
     <table>
       <tr>
         <td>
-          <label for="switch1">Vim enabeled</label>
+          <label for="switch1">Vim enabled</label>
         </td>
         <td>
           <label class="switch">


### PR DESCRIPTION
Fixed a spelling error in `src/index.html`:
```
enabeled --> enabled
```

That's it.
If there was some smaller way to do this than an entire pull request, please let me know!
I'd rather some small edit method than a pull request if I ever needed it again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Corrected a typographical error in the checkbox label text from "Vim enabeled" to "Vim enabled."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->